### PR TITLE
Replace keybind for "Open Log Panel" on OSX

### DIFF
--- a/config/keymap/Default (OSX).sublime-keymap
+++ b/config/keymap/Default (OSX).sublime-keymap
@@ -11,12 +11,6 @@
     // Update the user language of running user
     {"keys": ["alt+u"], "command": "update_user_language"},
 
-    {"keys": ["super+alt+`"], "command": "show_panel",
-        "args": {
-            "panel": "output.panel"
-        }
-    },
-
     // Open Document
     {"keys": ["super+alt+o"], "command": "open_documentation"},
 

--- a/util.py
+++ b/util.py
@@ -165,8 +165,7 @@ def show_output_panel(message, toggle=False):
     panel.set_syntax_file('Packages/Java/Java.tmLanguage')
     reminder_message = """You can open the output panel by below ways:
     1. Click SublimeApex > Debug > Open Log Panel in the main menu
-    2. Press Command + Alt + ` in OSX
-    3. Press Alt + ` in Windows
+    2. Press Alt + ` in Windows
     """
     panel.run_command('append', {'characters': reminder_message})
     panel.run_command('append', {'characters': message})


### PR DESCRIPTION
Since `super + `` is a built-in command on OSX responsible to change focus between open windows, it does not make sense mantain that keybing for SublimeApex.
So I changed the keybind to: `alt + `` and now it does not conflict anymore.
